### PR TITLE
Fix Validator parsing logic

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1038,18 +1038,24 @@ enum parse_rv parse_Validator(struct Validator_state *const state, parser_meta_s
       address_prompt_t pkh_prompt;
       pkh_prompt.network_id = meta->network_id;
       memcpy(&pkh_prompt.address, &state->addressState.val, sizeof(pkh_prompt.address));
-      INIT_SUBPARSER(uint64State, uint64_t);
-      if (ADD_PROMPT("Validator", &pkh_prompt, sizeof(address_prompt_t), validator_to_string)) break;
+      if (ADD_PROMPT("Validator", &pkh_prompt, sizeof(address_prompt_t), validator_to_string)) {
+        INIT_SUBPARSER(uint64State, uint64_t);
+        break;
+      }
     case 1:
       CALL_SUBPARSER(uint64State, uint64_t);
       state->state++;
-      INIT_SUBPARSER(uint64State, uint64_t);
-      if (ADD_PROMPT("Start time", &state->uint64State.val, sizeof(uint64_t), time_to_string)) break;
+      if (ADD_PROMPT("Start time", &state->uint64State.val, sizeof(uint64_t), time_to_string)) {
+        INIT_SUBPARSER(uint64State, uint64_t);
+        break;
+      }
     case 2:
       CALL_SUBPARSER(uint64State, uint64_t);
       state->state++;
-      INIT_SUBPARSER(uint64State, uint64_t);
-      if (ADD_PROMPT("End time", &state->uint64State.val, sizeof(uint64_t), time_to_string)) break;
+      if (ADD_PROMPT("End time", &state->uint64State.val, sizeof(uint64_t), time_to_string)) {
+        INIT_SUBPARSER(uint64State, uint64_t);
+        break;
+      }
     case 3:
       CALL_SUBPARSER(uint64State, uint64_t);
       state->state++;


### PR DESCRIPTION
Commit 733d7e95375b1f45e57dd0f83714fb06033cbf2f fixed a bug where the container used to hold parsed data was not fully erased.
Fixing this triggered a bug (that was not reachable before) in the parsing logic of Validator objects. Logic was:

- Init field parser
- Call field parser
- Init parser for next field
- Add parsed field data to the display queue

As parser initialization now correctly erases the whole field data, with this logic the parsed field data is blank.

Sequence has been moved to:

- Init field parser
- Call field parser
- Add parsed field data to the display queue
- Init parser for next field
